### PR TITLE
corrected package.json, since mn was missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Group 4",
   "license": "ISC",
   "dependencies": {
+    "modern-normalize": "^3.0.1",
     "vite-plugin-full-reload": "^1.2.0",
     "vite-plugin-html-inject": "^1.1.2"
   }


### PR DESCRIPTION
Somehow due to other merges, I guess, this line got missing - and it's important for the connection of mn due to which the deploy action can't work. It should work with it, hopefully.