### PR TITLE
changed the way of modern-normalize connection to enforce proper css loading order

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -5,6 +5,9 @@
   |============================
 */
 
+/* Modern-normalize */
+@import 'modern-normalize';
+
 /* Common variables */
 @import url('./utils/variables.css');
 

--- a/src/index.html
+++ b/src/index.html
@@ -12,7 +12,6 @@
     />
     <link rel="stylesheet" href="./css/styles.css" />
     <title>English Excellence</title>
-    <link rel="stylesheet" href="./css/styles.css" />
   </head>
   <body>
     <load src="./partials/header.html" />
@@ -26,7 +25,6 @@
       <load src="./partials/our-teachers.html" />
       <load src="./partials/application.html" />
       <load src="./partials/reviews.html" />
-
     </main>
 
     <load src="./partials/footer.html" />

--- a/src/main.js
+++ b/src/main.js
@@ -1,1 +1,0 @@
-import 'modern-normalize/modern-normalize.css';


### PR DESCRIPTION
In the previous method the MN could override our custom .css, which is undesirable. This new method should solve these issues and give more control on the order (also - be more robust wrt JS dependencies).